### PR TITLE
fix: semantic-release v10 config, CLI entry point, publish/Docker/docs fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     - name: Start container
       run: |
         docker run -d --name test-container -p 8000:8000 music21-mcp-test
-        sleep 10
+        sleep 30
     - name: Health check
       run: |
         curl -f http://localhost:8000/health || exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,17 +68,18 @@ jobs:
     
     - name: Install from wheel
       run: |
+        uv venv .venv
         uv pip install dist/*.whl
-        
+
     - name: Test import
       run: |
-        uv run python -c "import music21_mcp; print(music21_mcp.__version__)"
-        uv run python -c "from music21_mcp.services import MusicAnalysisService"
-        
+        .venv/bin/python -c "import music21_mcp; print(music21_mcp.__version__)"
+        .venv/bin/python -c "from music21_mcp.services import MusicAnalysisService"
+
     - name: Test CLI
       run: |
-        uv run music21-analysis --help || true
-        uv run music21-mcp --help || true
+        .venv/bin/music21-analysis --help || true
+        .venv/bin/music21-mcp --help || true
 
   publish:
     needs: [build, test]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,10 @@
 name: Release Drafter
 
+# Disabled: semantic-release handles versioning via conventional commits.
+# Release-drafter uses PR labels which conflicts and creates stale drafts.
+# Keep config (.github/release-drafter.yml) for manual use if needed.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ We use automated tools to ensure consistent code style:
 ## Testing Requirements
 
 ### Coverage Requirements
-- **Minimum Coverage**: 80%
-- **Target Coverage**: >80%
+- **Minimum Coverage**: 82%
+- **Target Coverage**: >82%
 
 ### Running Tests
 
@@ -106,7 +106,7 @@ pytest tests/
 # Run with coverage
 pytest tests/ --cov=src/music21_mcp --cov-report=term-missing
 
-# Run with coverage threshold (will fail if below 80%)
+# Run with coverage threshold (will fail if below 82%)
 pytest tests/ --cov=src/music21_mcp --cov-fail-under=82
 
 # Run specific test file
@@ -232,7 +232,7 @@ Your PR must pass all automated checks:
 2. **Tests**
    - All unit tests pass
    - All integration tests pass
-   - Coverage remains above 80%
+   - Coverage remains above 82%
 
 3. **Security Scan**
    - Bandit security scan passes

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ENV PYTHONUNBUFFERED=1 \
     MUSIC21_MCP_TIMEOUT=30
 
 # Health check - uses the HTTP health endpoint
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Switch to non-root user

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ analysis = analyzer.quick_analysis("chorale")
 python -m pytest tests/ -v
 
 # Run with coverage threshold
-python -m pytest tests/ --cov=src/music21_mcp --cov-fail-under=80
+python -m pytest tests/ --cov=src/music21_mcp --cov-fail-under=82
 ```
 
 ### Development Setup
@@ -309,14 +309,14 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 - Development setup and requirements
 - Code style guidelines (Ruff, MyPy)
-- Testing requirements (maintain >80% coverage)
+- Testing requirements (maintain >82% coverage)
 - Pull request process
 - Branch protection rules
 
 Quick start:
 1. Fork the repository
 2. Create feature branch: `git checkout -b feature/amazing-feature`
-3. Run tests: `pytest tests/ --cov=src/music21_mcp --cov-fail-under=80`
+3. Run tests: `pytest tests/ --cov=src/music21_mcp --cov-fail-under=82`
 4. Commit changes: `git commit -m 'feat: Add amazing feature'`
 5. Push branch: `git push origin feature/amazing-feature`
 6. Submit pull request

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -6,7 +6,7 @@ The Music21 MCP Server uses GitHub Actions for continuous integration and deploy
 
 ## Current Status
 
-- **Coverage**: 84%+ (Required: 80%)
+- **Coverage**: 84%+ (Required: 82%)
 - **Python Versions**: 3.10, 3.11, 3.12
 - **Protected Branch**: main
 - **Auto-deployment**: PyPI on tag push
@@ -26,7 +26,7 @@ The Music21 MCP Server uses GitHub Actions for continuous integration and deploy
 
 #### Run Tests
 - **Matrix**: Python 3.10, 3.11, 3.12
-- **Coverage**: Must maintain >80% coverage
+- **Coverage**: Must maintain >82% coverage
 - **Tools**: pytest with coverage reporting
 - **Reports**: Coverage badge updated automatically
 
@@ -150,7 +150,7 @@ The Music21 MCP Server uses GitHub Actions for continuous integration and deploy
 
 4. **CI Pipeline Runs**
    - All checks must pass
-   - Coverage must stay above 80%
+   - Coverage must stay above 82%
    - Security scans must pass
 
 5. **Code Review**
@@ -283,7 +283,7 @@ chore: Update dependencies
 ### Testing
 
 - Write tests before code (TDD)
-- Maintain >80% coverage
+- Maintain >82% coverage
 - Test edge cases
 - Mock external dependencies
 

--- a/docs/simplified-api.md
+++ b/docs/simplified-api.md
@@ -371,21 +371,6 @@ Analyze musical style characteristics and generate new music following those pat
 - `score_id` (str): ID of the reference score
 - `target_style` (str, optional): `"bach"`, `"mozart"`, `"chopin"`, `"beethoven"`, `"jazz"` (default: `"bach"`)
 
-### 14. health_check
-
-Check server health and operational status.
-
-**Parameters:** None
-
-**Returns:**
-```json
-{
-  "status": "healthy",
-  "tools_available": 14,
-  "memory_usage": "24.5 MB"
-}
-```
-
 ## Error Handling
 
 All tools return consistent error responses:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ packages = [{include = "music21_mcp", from = "src"}]
 music21-analysis = "music21_mcp.launcher:main"
 music21-mcp = "music21_mcp.server_minimal:main"
 music21-http = "music21_mcp.adapters.http_adapter:main"
-music21-cli = "music21_mcp.adapters.cli_adapter:main"
+music21-cli = "music21_mcp.adapters.cli_adapter:main_sync"
 
 [project.urls]
 "Homepage" = "https://github.com/brightlikethelight/music21-mcp-server"
@@ -228,10 +228,13 @@ exclude_dirs = ["tests", "examples", "debug_test.py"]
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/music21_mcp/__init__.py:__version__"]
-branch = "main"
 commit_message = "chore(release): {version}"
 build_command = "uv build"
 upload_to_pypi = false  # handled by publish.yml on release event
+
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "revert", "build", "chore", "ci", "docs", "style", "test"]

--- a/src/music21_mcp/adapters/cli_adapter.py
+++ b/src/music21_mcp/adapters/cli_adapter.py
@@ -259,5 +259,10 @@ Examples:
         traceback.print_exc()
 
 
-if __name__ == "__main__":
+def main_sync():
+    """Sync wrapper for entry point (pyproject.toml console_scripts)."""
     asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main_sync()


### PR DESCRIPTION
## Summary

Fixes 7 distinct issues discovered during comprehensive repo audit:

### Critical
- **semantic-release v10 config migration**: `branch = "main"` (v9 format) → `[tool.semantic_release.branches.main]` (v10 format). **Root cause of automated releases not being created** — v10.5.3 doesn't recognize the old `branch` directive.
- **CLI entry point broken**: `async def main()` called synchronously by `console_scripts` entry point. Added sync wrapper `main_sync()`.
- **publish.yml test job**: `uv pip install` without venv fails on PEP 668 externally managed Python. Creates explicit venv.

### Important
- **Docker health check timing**: `start-period=5s` → `30s` (server needs ~12s to warm caches). CI Docker test wait `10s` → `30s`.
- **Release-drafter disabled**: Auto-trigger on push conflicts with semantic-release. Changed to manual `workflow_dispatch` only.
- **simplified-api.md**: Removed non-existent `health_check` tool entry (was claiming 14 tools, actual is 13).

### Docs
- **Coverage threshold**: 80% → 82% across README.md, CONTRIBUTING.md, docs/CI_CD_GUIDE.md to match actual `--cov-fail-under=82` in pyproject.toml.

## Test plan
- [ ] CI green on all required checks
- [ ] `music21-cli --help` works (entry point fix)
- [ ] `semantic-release version --print` outputs `1.0.1` on main after merge
- [ ] Docker build test passes with extended timing
- [ ] Publish workflow passes when triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)