### PR TITLE
fix: publish.yml venv activation, release.yml fetch-tags, add Python 3.13

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -108,13 +108,13 @@ template: |
   - **13 comprehensive music analysis tools**
   - **4 different interfaces**: MCP Server, HTTP API, CLI, Python Library  
   - **Protocol-independent architecture** for maximum reliability
-  - **Professional CI/CD** with 80%+ test coverage
+  - **Professional CI/CD** with 82%+ test coverage
   - **Security scanning** and type checking
   
   ## 📊 Stats
   
   - **Python**: 3.10+ supported
-  - **Test Coverage**: 80%+ with comprehensive test suite
+  - **Test Coverage**: 82%+ with comprehensive test suite
   - **Security**: Scanned with bandit, pip-audit, safety
   - **Type Checking**: Full mypy coverage
   

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     
     steps:
     - uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
     - name: Install from wheel
       run: |
         uv venv .venv
-        uv pip install dist/*.whl
+        VIRTUAL_ENV=.venv uv pip install dist/*.whl
 
     - name: Test import
       run: |
@@ -78,8 +78,8 @@ jobs:
 
     - name: Test CLI
       run: |
-        .venv/bin/music21-analysis --help || true
-        .venv/bin/music21-mcp --help || true
+        .venv/bin/music21-analysis --help
+        .venv/bin/music21-mcp --help
 
   publish:
     needs: [build, test]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        fetch-tags: true
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up UV

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -7,7 +7,7 @@ The Music21 MCP Server uses GitHub Actions for continuous integration and deploy
 ## Current Status
 
 - **Coverage**: 84%+ (Required: 82%)
-- **Python Versions**: 3.10, 3.11, 3.12
+- **Python Versions**: 3.10, 3.11, 3.12, 3.13
 - **Protected Branch**: main
 - **Auto-deployment**: PyPI on tag push
 
@@ -25,7 +25,7 @@ The Music21 MCP Server uses GitHub Actions for continuous integration and deploy
 - **Required**: Yes (blocks merge)
 
 #### Run Tests
-- **Matrix**: Python 3.10, 3.11, 3.12
+- **Matrix**: Python 3.10, 3.11, 3.12, 3.13
 - **Coverage**: Must maintain >82% coverage
 - **Tools**: pytest with coverage reporting
 - **Reports**: Coverage badge updated automatically

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -48,7 +48,7 @@ git log --oneline -5 origin/fix/test-failures
 
 ### ✅ Completed Items
 - [x] All 54 test failures resolved
-- [x] Test coverage: 84%+ (exceeds 80% requirement)
+- [x] Test coverage: 84%+ (exceeds 82% requirement)
 - [x] All linting issues fixed (ruff, mypy)
 - [x] Security scans configured (bandit, pip-audit)
 - [x] Documentation complete:
@@ -76,7 +76,7 @@ git log --oneline -5 origin/fix/test-failures
 ### Phase 1: Pre-Merge (Current Phase)
 - [ ] **Monitor CI Status** using alternative methods above
 - [ ] **Verify all CI jobs pass** on fix/test-failures branch
-- [ ] **Review final test coverage report** (target: >80%, current: 84%+)
+- [ ] **Review final test coverage report** (target: >82%, current: 84%+)
 - [ ] **Confirm security scans pass** (bandit, pip-audit)
 - [ ] **Validate build artifacts** are created successfully
 
@@ -107,7 +107,7 @@ git log --oneline -5 origin/fix/test-failures
 
 ### Test Coverage
 - **Current Coverage**: 84%+
-- **Target Coverage**: 80%
+- **Target Coverage**: 82%
 - **Status**: ✅ EXCEEDS REQUIREMENT
 
 ### Test Results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Sound/Audio :: Analysis",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]


### PR DESCRIPTION
## Summary

Third round of fixes from comprehensive 30-subagent audit:

### Critical
- **publish.yml venv activation**: `uv pip install` without `VIRTUAL_ENV` set silently installs to system Python, not the `.venv`. Wheel verification was passing by accident. Added `VIRTUAL_ENV=.venv` prefix. Removed `|| true` from CLI tests to catch real failures.
- **release.yml fetch-tags**: `actions/checkout@v6` defaults `fetch-tags: false` (breaking change from v3). Semantic-release needs tags to determine version baseline. Tags happened to be fetched via explicit refspec, but this is fragile — now explicit.

### Important
- **Python 3.13 classifier**: CI already tests 3.13, all deps support it, 493 tests pass. Added to pyproject.toml classifiers and publish.yml test matrix for consistency.

### Docs
- **Coverage threshold**: Remaining 80% → 82% fixes in release-checklist.md and release-drafter.yml.
- **Python versions**: Updated CI_CD_GUIDE.md to include 3.13.

## Test plan
- [ ] CI green on all required checks
- [ ] publish.yml test job installs wheel into `.venv/` (not system Python)
- [ ] `.venv/bin/music21-analysis --help` and `.venv/bin/music21-mcp --help` succeed without `|| true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)